### PR TITLE
Explain config_options and correct syntax in stunnel.conf.erb.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ default[:stunnel][:default][:files] = '/etc/stunnel/*.conf'
 default[:stunnel][:default][:options] = ''
 ```
 
+There is also an array to specify extra configuration options in stunnel.conf that aren't explicitly exposed with attributes.
+```ruby
+node.default[:stunnel][:config_options] = ['your_param=value','another_param=value']
+
+include_recipe 'stunnel'
+```
+
 ## Infos
 * Repository: https://github.com/hw-cookbooks/stunnel
 * IRC: Freenode @ #heavywater

--- a/templates/default/stunnel.conf.erb
+++ b/templates/default/stunnel.conf.erb
@@ -32,7 +32,7 @@ compression = <%= node[:stunnel][:compression] %>
 
 <% if node[:stunnel][:config_options] -%>
   <% Array(node[:stunnel][:config_options]).each do |opt| -%>
-options = <%= opt %>
+<%= opt %>
   <% end -%>
 <% end -%>
 


### PR DESCRIPTION
The config_options array is a powerful way to pass-in configuration options to the stunnel config file, but the current syntax is broken.
