### PR TITLE
Adds the protocol option when creating a STunnel server

### DIFF
--- a/providers/connection.rb
+++ b/providers/connection.rb
@@ -34,7 +34,8 @@ action :create do
     cert: new_resource.cert,
     verify: new_resource.verify,
     timeout_close: new_resource.timeout_close,
-    client: new_resource.client
+    client: new_resource.client,
+    protocol: new_resource.protocol
   )
   exist = Mash.new(node['stunnel']['services'][new_resource.service_name])
   if(exist != hsh)

--- a/resources/connection.rb
+++ b/resources/connection.rb
@@ -28,3 +28,4 @@ attribute :cert, kind_of: String
 attribute :verify, kind_of: Integer
 attribute :timeout_close, kind_of: [TrueClass,FalseClass]
 attribute :client, kind_of: [TrueClass,FalseClass]
+attribute :protocol, kind_of: String

--- a/templates/default/stunnel.conf.erb
+++ b/templates/default/stunnel.conf.erb
@@ -80,7 +80,7 @@ TIMEOUTclose = 0
 
 <% node['stunnel']['services'].each do |name, opts| -%>
 [<%= name %>]
-<% %w[connect accept cert verify].each do |opt| -%>
+<% %w[connect accept cert verify protocol].each do |opt| -%>
 <% unless opts[opt].nil? -%>
 <%= opt %> = <%= opts[opt] %>
 <% end -%>


### PR DESCRIPTION
This allows a particular protocol to be configured with a given connection.
See https://www.stunnel.org/static/stunnel.html for a list of available options.

``` ruby
stunnel_connection 'postgres_pgbouncer' do
  accept node['postgres']['stunnel']['port']
  connect node['postgres']['pgbouncer']['port']
  protocol 'pgsql'
  notifies :reload, 'service[stunnel]'
end
```
