### PR TITLE
add boolen attribute to control whether stunnel forks or not

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,6 +15,7 @@ default[:stunnel][:chroot_path] = "/usr/var/lib/stunnel"
 default[:stunnel][:pidfile] = "/tmp/stunnel.pid"
 default[:stunnel][:user] = "root"
 default[:stunnel][:group] = "root"
+default[:stunnel][:foreground] = false
 
 default[:stunnel][:https][:enabled] = false
 default[:stunnel][:https][:accept_port] = "443"

--- a/files/default/stunnel4.service
+++ b/files/default/stunnel4.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=stunnel TLS proxy
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/stunnel
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,9 +19,13 @@ unless(node.platform_family == 'debian')
     shell '/bin/false'
     supports :manage_home => true
   end
-  cookbook_file '/etc/init.d/stunnel4' do
-    source 'stunnel4'
-    mode 0755
+  if node.platform_family == 'rhel' && node['platform_version'].to_i >= 7
+    include_recipe 'stunnel::systemd_service'
+  else
+    cookbook_file '/etc/init.d/stunnel4' do
+      source 'stunnel4'
+      mode 0755
+    end
   end
 end
 

--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -1,0 +1,9 @@
+# Our systemd service uses the "simple" service type, so we need
+# stunnel not to fork, and consequently have no need for a pid file.
+node.override['stunnel']['foreground'] = true
+node.override['stunnel']['pid'] = ''
+
+cookbook_file '/etc/systemd/system/stunnel4.service' do
+  source 'stunnel4.service'
+  mode 0644
+end

--- a/templates/default/stunnel.conf.erb
+++ b/templates/default/stunnel.conf.erb
@@ -20,6 +20,7 @@ setuid = <%= node[:stunnel][:user] %>
 setgid = <%= node[:stunnel][:group] %>
 ; PID is created inside the chroot jail
 pid = <%= node[:stunnel][:pidfile] %>
+foreground = <%= node[:stunnel][:foreground] ? 'yes' : 'no' %>
 
 ; performance tunings
 <% Array(node[:stunnel][:socket_tunings]).each do |s| -%>


### PR DESCRIPTION
Keeping stunnel in the foreground made it easier for me to manage with systemd
