### PR TITLE
Make the pid file match the defaults in the init

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ default['stunnel']['cert_fqdn'] = node['fqdn']
 
 default['stunnel']['use_chroot'] = false
 default['stunnel']['chroot_path'] = "/usr/var/lib/stunnel"
-default['stunnel']['pidfile'] = "/tmp/stunnel.pid"
+default['stunnel']['pidfile'] = "/var/run/stunnel4.pid"
 default['stunnel']['user'] = "root"
 default['stunnel']['group'] = "root"
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,7 @@ default['stunnel']['source_checksum'] = '9cae2cfbe26d87443398ce50d7d5db54e5ea363
 
 default['stunnel']['use_chroot'] = false
 default['stunnel']['chroot_path'] = '/usr/var/lib/stunnel'
-default['stunnel']['pidfile'] = '/tmp/stunnel.pid'
+default['stunnel']['pidfile'] = '/var/run/stunnel4.pid'
 default['stunnel']['user'] = 'root'
 default['stunnel']['group'] = 'root'
 


### PR DESCRIPTION
This change shouldn't be breaking but will not actually make a meaningful change to the system until the service is restarted. But some testing might be good.
Fixes #28 
